### PR TITLE
adding workflow for publishing to open source vscode registry

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -9,7 +9,10 @@ pool:
 steps:
 - script: |
     npm install
+    npm i -g ovsx
     npx vsce publish -p ${VSCE_TOKEN}
+    npx ovsx publish -p ${OVSX_TOKEN}
   env:
     VSCE_TOKEN: $(vsce.token)
+    OVSX_TOKEN: $(osvx.token)
   displayName: 'Publish to the marketplace'


### PR DESCRIPTION
I was looking to get this extension added to the open-source vscode registry osvx. I added the mechanism in the pipeline to get it published but you'll need to do a couple more things to get an access token and add it to azure. 

https://github.com/eclipse/openvsx/wiki/Publishing-Extensions#how-to-publish-an-extension

Let me know if I can help further in getting this published to osvx